### PR TITLE
Removed "2014" from Form title

### DIFF
--- a/Civil3DSnoopDB.bundle/Contents/Source/SnoopCivil3D/frmSnoopObjects.Designer.vb
+++ b/Civil3DSnoopDB.bundle/Contents/Source/SnoopCivil3D/frmSnoopObjects.Designer.vb
@@ -99,7 +99,7 @@ Partial Class frmSnoopObjects
     Me.MinimizeBox = False
     Me.Name = "frmSnoopObjects"
     Me.ShowInTaskbar = False
-    Me.Text = "Snoop Civil 3D 2014 Database"
+    Me.Text = "Snoop Civil 3D Database"
     Me.ResumeLayout(False)
 
   End Sub


### PR DESCRIPTION
As SnoopCivil3D is meant to be relatively version-agnostic, the Form it generates will work for multiple versions of AutoCAD Civil 3D, not just Version 2014
